### PR TITLE
Update Ruffle to use CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-ruffle
 cp-swf-archive/
 *.code-workspace
 *.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,10 +29,8 @@ pages:
     - make
   script:
     - rm -f *.md
-    - mkdir -p public ruffle
-    - wget --output-document ruffle.zip https://github.com/ruffle-rs/ruffle/releases/download/nightly-2021-06-27/ruffle-nightly-2021_06_27-web-selfhosted.zip
-    - unzip ruffle.zip -d ruffle
-    - mv cp-swf-archive index.html main.js ports.js main.css ruffle public
+    - mkdir -p public
+    - mv cp-swf-archive index.html main.js ports.js main.css public
     - tree -J public/cp-swf-archive > public/cp-swf-archive/archive.json
     - git fetch
     - git checkout pages

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <title>Club Penguin Archive</title>
     <script src="main.js"></script>
     <script src="ports.js"></script>
-    <script src="ruffle/ruffle.js"></script>
+    <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
     <script async defer data-website-id="7d735b74-bd1d-4b20-ae98-f05b3bc9a109" data-domains="cpswf.barichello.me" src="https://log.aa.art.br/script.js"></script>
     <link rel="stylesheet" href="main.css">
 </head>


### PR DESCRIPTION
The ruffle version used currently on the archive is a very old, two year old Ruffle version.

We should use the Ruffle CDN instead to always load the latest version of Ruffle.